### PR TITLE
fix mcquant input problem

### DIFF
--- a/workflows/tspc.nf
+++ b/workflows/tspc.nf
@@ -92,7 +92,12 @@ workflow TSPC {
     //
     // Mcquant
     //
-    MCQUANT(BACKSUB.out.backsub_tif, CELLPOSESAM.out.mask, markersheet_tuple)
+    if (params.do_backsub) {
+        MCQUANT(BACKSUB.out.backsub_tif, CELLPOSESAM.out.mask, markersheet_tuple)
+    } else {
+        MCQUANT(image_tuple, CELLPOSESAM.out.mask, markersheet_tuple)
+    }
+    
     // mc_quant_ch = MCQUANT(backsub_img[0], cellpose_ch, markers_nsclc_ch)
 
     //


### PR DESCRIPTION

This fixes #6 
Currently MCQUANT tries to use the background subtracted image for quantification, even if backsub is set to false. I added an if statement similar to the other modules to use backsub_tif when backsub is on and otherwise use the normal image. 



