### PR TITLE
Fix BACKSUB.output markers issue

### DIFF
--- a/conf/helix_gpu.config
+++ b/conf/helix_gpu.config
@@ -19,7 +19,7 @@ process {
     time   = { 4.h    * task.attempt }
 
     errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'finish' }
-    maxRetries    = 1
+    maxRetries    = 3
     maxErrors     = '-1'
 
     // Process-specific resource requirements
@@ -63,7 +63,9 @@ process {
         maxRetries    = 2
     }
     withLabel:process_gpu {
-        clusterOptions = '--partition=gpu-single --ntasks-per-node=1 --gres=gpu:H200:1 --mem=512gb'
+        queue          = 'gpu-single'
+        clusterOptions = '--ntasks-per-node=4 --gres=gpu:1,gpumem_per_gpu:80GB'
+        memory         = 256.GB
         ext.use_gpu = { workflow.profile.contains('gpu') }
         accelerator = { workflow.profile.contains('gpu') ? 1 : null }
     }

--- a/modules/nf-core/mcquant/main.nf
+++ b/modules/nf-core/mcquant/main.nf
@@ -1,6 +1,6 @@
 process MCQUANT {
     tag "$meta.id"
-    label 'process_single'
+    label 'process_medium'
 
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     container "nf-core/quantification:1.5.4"

--- a/nextflow.config
+++ b/nextflow.config
@@ -238,4 +238,4 @@ validation {
 }
 
 // Load modules.config for DSL2 module specific options
-includeConfig 'conf/modules.config'
+includeConfig 'conf/helix_gpu.config'

--- a/workflows/tspc.nf
+++ b/workflows/tspc.nf
@@ -93,7 +93,7 @@ workflow TSPC {
     // Mcquant
     //
     if (params.do_backsub) {
-        MCQUANT(BACKSUB.out.backsub_tif, CELLPOSESAM.out.mask, markersheet_tuple)
+        MCQUANT(BACKSUB.out.backsub_tif, CELLPOSESAM.out.mask, BACKSUB.out.markerout)
     } else {
         MCQUANT(image_tuple, CELLPOSESAM.out.mask, markersheet_tuple)
     }


### PR DESCRIPTION
Solving issue #2 but collecting the right output for the markers channels after the backsub module. Also added correct cluster options for running cellpose and avoiding memory issues.