### PR TITLE
Include modules.config in nextflow configuration and add channel joining

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -239,3 +239,4 @@ validation {
 
 // Load modules.config for DSL2 module specific options
 includeConfig 'conf/helix_gpu.config'
+includeConfig 'conf/modules.config'

--- a/workflows/tspc.nf
+++ b/workflows/tspc.nf
@@ -93,10 +93,29 @@ workflow TSPC {
     // Mcquant
     //
     if (params.do_backsub) {
-        MCQUANT(BACKSUB.out.backsub_tif, CELLPOSESAM.out.mask, BACKSUB.out.markerout)
+        ch_mcquant = BACKSUB.out.backsub_tif
+            .join(CELLPOSESAM.out.mask)
+            .join(BACKSUB.out.markerout)
+        MCQUANT(
+            ch_mcquant.map { meta, img, mask, marker -> tuple(meta, img) },
+            ch_mcquant.map { meta, img, mask, marker -> tuple(meta, mask) },
+            ch_mcquant.map { meta, img, mask, marker -> tuple(meta, marker) }
+        )
     } else {
-        MCQUANT(image_tuple, CELLPOSESAM.out.mask, markersheet_tuple)
+        ch_mcquant = image_tuple
+            .join(CELLPOSESAM.out.mask)
+            .join(markersheet_tuple)
+        MCQUANT(
+            ch_mcquant.map { meta, img, mask, marker -> tuple(meta, img) },
+            ch_mcquant.map { meta, img, mask, marker -> tuple(meta, mask) },
+            ch_mcquant.map { meta, img, mask, marker -> tuple(meta, marker) }
+        )
     }
+    // if (params.do_backsub) {
+    //     MCQUANT(BACKSUB.out.backsub_tif, CELLPOSESAM.out.mask, BACKSUB.out.markerout)
+    // } else {
+    //     MCQUANT(image_tuple, CELLPOSESAM.out.mask, markersheet_tuple)
+    // }
     
     // mc_quant_ch = MCQUANT(backsub_img[0], cellpose_ch, markers_nsclc_ch)
 


### PR DESCRIPTION
This commit adds the pdules.config back into the nextflow.config so the files are published in the output directory. This Closes #11 

EDIT (12.05.2026):
I also added channel joining to `workflow/tspc.nf' MCQUANT part. It uses `.join()` to join correct images, masks and markersheet from backsub. Tested on current TSPC image data. But maybe we could think about adding a test that verifies that the correct fiels are joined? 
This Closes #10 

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/tanevskilab/tspc/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
